### PR TITLE
feat(oh-my-posh): atualize as definições do tema

### DIFF
--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -8,6 +8,14 @@
           "background": "p:violet",
           "foreground": "p:white",
           "leading_diamond": "\ue0b6",
+          "properties": {
+            "debian": "\uf306",
+            "linux": "\ue712",
+            "macos": "\ue711",
+            "raspbian": "\uf315",
+            "ubuntu": "\uf31c",
+            "windows": "\ue70f"
+          },
           "style": "diamond",
           "type": "os"
         },

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -55,6 +55,13 @@
           },
           "style": "powerline",
           "type": "git"
+        }
+      ],
+      "type": "prompt"
+    },
+    {
+      "alignment": "right",
+      "segments": [
         },
         {
           "background": "#5c2d91",

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -5,15 +5,15 @@
       "alignment": "left",
       "segments": [
         {
-          "background": "#6272a4",
-          "foreground": "#f8f8f2",
+          "background": "p:violet",
+          "foreground": "p:white",
           "leading_diamond": "\ue0b6",
           "style": "diamond",
           "type": "os"
         },
         {
           "background": "#61afef",
-          "foreground": "#fff",
+          "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "properties": {
             "style": "folder"
@@ -22,14 +22,14 @@
           "type": "path"
         },
         {
-          "background": "#2fda4e",
+          "background": "p:yellow",
           "background_templates": [
-            "{{ if or (.Working.Changed) (.Staging.Changed) }}#ffeb95{{ end }}",
-            "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#f26d50{{ end }}",
-            "{{ if gt .Ahead 0 }}#b388ff{{ end }}",
-            "{{ if gt .Behind 0 }}#f17c37{{ end }}"
+            "{{ if or (.Working.Changed) (.Staging.Changed) }}p:light_yellow{{ end }}",
+            "{{ if and (gt .Ahead 0) (gt .Behind 0) }}p:light_orange{{ end }}",
+            "{{ if gt .Ahead 0 }}p:light_purple{{ end }}",
+            "{{ if gt .Behind 0 }}p:orange{{ end }}"
           ],
-          "foreground": "#333",
+          "foreground": "p:black",
           "powerline_symbol": "\ue0b0",
           "properties": {
             "fetch_stash_count": true,
@@ -42,7 +42,7 @@
         },
         {
           "background": "#5c2d91",
-          "foreground": "#fff",
+          "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "style": "powerline",
           "template": " \ue77f {{ if .Unsupported }}\uf071{{ else }}{{ .Full }}{{ end }}",
@@ -50,7 +50,7 @@
         },
         {
           "background": "#777bb4",
-          "foreground": "#fff",
+          "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "style": "powerline",
           "template": " {{ if .Error }}[PHP]{{ .Error }}{{ else }}\ue73d {{ .Full }}{{ end }} ",
@@ -58,7 +58,7 @@
         },
         {
           "background": "#6ca35e",
-          "foreground": "#fff",
+          "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "properties": {
             "fetch_package_manager": true,
@@ -71,7 +71,7 @@
         },
         {
           "background": "#c3002f",
-          "foreground": "#fff",
+          "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "style": "powerline",
           "type": "angular"
@@ -94,6 +94,17 @@
   ],
   "console_title_template": "{{.Folder}}{{if .Root}} :: root{{end}} :: {{.Shell}}",
   "final_space": true,
-  "osc99": true,
-  "version": 2
+  "palette": {
+    "black": "#282a36",
+    "red": "#e91e63",
+    "light_blue": "#61afef",
+    "light_orange": "#f26d50",
+    "light_purple": "#b388ff",
+    "light_yellow": "#ffeb95",
+    "orange": "#f17c37",
+    "violet": "#6272a4",
+    "white": "#f8f8f2",
+    "yellow": "#2fda4e"
+  },
+  "version": 3
 }

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -90,14 +90,16 @@
           "background": "#6ca35e",
           "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
-          "properties": {
-            "fetch_package_manager": true,
-            "npm_icon": "<#cc3a3a>\ue71e</>",
-            "yarn_icon": "<#348cba>\uf61a</>"
-          },
           "style": "powerline",
           "template": " \uf898 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} ",
           "type": "node"
+        },
+        {
+          "background": "#cc3a3a",
+          "foreground": "p:white",
+          "powerline_symbol": "\ue0b0",
+          "style": "powerline",
+          "type": "npm"
         },
         {
           "background": "#c3002f",

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -20,7 +20,14 @@
           "type": "os"
         },
         {
-          "background": "#61afef",
+          "background": "p:violet",
+          "foreground": "p:white",
+          "style": "diamond",
+          "template": " {{ .UserName }}@{{ .HostName }} ",
+          "trailing_diamond": "\ue0b0",
+          "type": "session"
+        },
+        {
           "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "properties": {

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -62,6 +62,13 @@
     {
       "alignment": "right",
       "segments": [
+        {
+          "background": "#5c2d91",
+          "foreground": "p:white",
+          "powerline_symbol": "\ue0b0",
+          "style": "powerline",
+          "template": " \ue7b0 {{ .Context }}",
+          "type": "docker"
         },
         {
           "background": "#5c2d91",

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -109,16 +109,30 @@
           "type": "angular"
         },
         {
-          "type": "status",
+          "background": "#0077c2",
+          "foreground": "p:white",
+          "leading_diamond": "<transparent,background>\ue0b0</>",
           "style": "diamond",
-          "foreground": "#ffffff",
-          "background": "#00897b",
-          "background_templates": ["{{ if gt .Code 0 }}#e91e63{{ end }}"],
+          "template": " \uf120 {{ .Name }}",
           "trailing_diamond": "\ue0b4",
-          "template": " {{ if gt .Code 0 }}\uf525{{ else }}\uf469{{ end }} ",
+          "type": "shell"
+        }
+      ],
+      "type": "prompt"
+    },
+    {
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "foreground": "#00897b",
+          "foreground_templates": ["{{ if gt .Code 0 }}p:red{{ end }}"],
           "properties": {
             "always_enabled": true
-          }
+          },
+          "style": "plain",
+          "template": "\u276f",
+          "type": "status"
         }
       ],
       "type": "prompt"

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -28,6 +28,7 @@
           "type": "session"
         },
         {
+          "background": "p:light_blue",
           "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "properties": {

--- a/private_dot_config/oh-my-posh/renebentes.omp.json
+++ b/private_dot_config/oh-my-posh/renebentes.omp.json
@@ -83,7 +83,7 @@
           "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "style": "powerline",
-          "template": " {{ if .Error }}[PHP]{{ .Error }}{{ else }}\ue73d {{ .Full }}{{ end }} ",
+          "template": " \ue73d {{ .Full }} ",
           "type": "php"
         },
         {


### PR DESCRIPTION
Este PR inclui:

- A definição de uma paleta de cores padrões de forma a facilitar a utilização em vários locais, sem que seja necessário pesquisar qual hexadecimal correspondente;
- Os ícones para exibir quando os principais sistemas operacionais estiverem em uso;
- Exibição da seção de usuário;
- Separação de segmentos com base em contextos, informações sobre sistema em uso, seção e pastas alinhados à esquerda, e tecnologias, linguagens, frameworks à direita
- O status de execução de um comando agora é exibido na segunda linha de prompt.